### PR TITLE
lambda/main.py: dont use vendored requests

### DIFF
--- a/lambda/main.py
+++ b/lambda/main.py
@@ -6,7 +6,7 @@ import threading
 import logging
 import re
 
-from botocore.vendored import requests
+import requests
 import boto3
 
 # semaphore limit of 5, picked this number arbitrarily


### PR DESCRIPTION
Ran into [this issue](https://stackoverflow.com/questions/57495522/how-to-fix-attributeerror-module-botocore-vendored-requests-has-no-attribute). Fixed by using `import requests`